### PR TITLE
README: insert whitespace before title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-#CentOS 7 box for Vagrant (virtualbox)
+# CentOS 7 box for Vagrant (virtualbox)
 
 This repo contain definition files to build a
 [Vagrant](http://www.vagrantup.com) box.
 
-##Dependencies
+## Dependencies
 
 You need to install [Vagrant](http://www.vagrantup.com) and
 [veewee](https://github.com/jedi4ever/veewee) with your favorite package
 manager to build the image.
 
-##Running
+## Running
 
 Just run the following command in the repository root:
 


### PR DESCRIPTION
README is not correctly rendered at github.com (see https://github.com/adfinis-sygroup/vagrant-centos7-box).